### PR TITLE
No need to request upload auth when calling login()

### DIFF
--- a/thunner
+++ b/thunner
@@ -109,7 +109,7 @@ def apiinit(email,password):
     
     logged_in = False
     attempts = 0
-    api.login(email, password)
+    api.login(email, password, False)
     return api
 
 def scrinit():


### PR DESCRIPTION
Ref: https://github.com/simon-weber/Unofficial-Google-Music-API/issues/111
The api issue is resolved, but in order to avoid any future issues,
set perform_upload_auth=False when perform a login.
