### PR TITLE
Fix crash in list_playlists()

### DIFF
--- a/thunner
+++ b/thunner
@@ -243,10 +243,9 @@ def gen_trees(library):
 
 def list_playlists(api,playlist_ids):
     playlists = []
-    for name,pid in playlist_ids['user'].iteritems():
-        playlists.append( { "name":name, "subtree":api.get_playlist_songs(pid), "subtreeline":0 } )
-    for name,pid in playlist_ids['auto'].iteritems():
-        playlists.append( { "name":name, "subtree":api.get_playlist_songs(pid), "subtreeline":0 } )
+    for name,pids in playlist_ids['user'].iteritems():
+        for pid in pids:
+            playlists.append( { "name":name, "subtree":api.get_playlist_songs(pid), "subtreeline":0 } )
     return playlists 
 
 def headphones(scr,height,code):


### PR DESCRIPTION
Google Music allows multiple user playlists with the same name,
so the 'user' dictionary will map onto lists of ids.

There is currently no support for retrieving automatically-created
instant mixes, so removing "auto".

Please see:
http://unofficial-google-music-api.readthedocs.org/en/latest/reference/api.html#gmusicapi.api.Api.get_all_playlist_ids
and
https://github.com/simon-weber/Unofficial-Google-Music-API/issues/67
